### PR TITLE
fix: fill start in dataset first point

### DIFF
--- a/app/src/main/java/com/yabu/livechartdemoapp/MainActivity.kt
+++ b/app/src/main/java/com/yabu/livechartdemoapp/MainActivity.kt
@@ -69,7 +69,7 @@ class MainActivity : AppCompatActivity() {
         livechart.setDataset(dataset)
             .setLiveChartStyle(style)
             .drawYBounds()
-            .drawFill()
+            .drawFill(withGradient = true)
             .drawBaseline()
             .drawLastPointLabel()
             .drawBaselineConditionalColor()

--- a/app/src/main/java/com/yabu/livechartdemoapp/SampleData.kt
+++ b/app/src/main/java/com/yabu/livechartdemoapp/SampleData.kt
@@ -235,7 +235,7 @@ object SampleData {
 
         val data = Gson().fromJson(json, TestDataResponse::class.java)
         return Dataset(data.mapIndexed { index, it ->
-            DataPoint(index.toFloat(), it.close.toFloat())
+            DataPoint(index.toFloat() + 16, it.close.toFloat())
         }.toMutableList())
     }
 

--- a/livechart/build.gradle
+++ b/livechart/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 2
-        versionName "1.3.3"
+        versionName "1.3.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/livechart/src/main/java/com/yabu/livechart/view/LiveChartView.kt
+++ b/livechart/src/main/java/com/yabu/livechart/view/LiveChartView.kt
@@ -611,7 +611,8 @@ open class LiveChartView(context: Context, attrs: AttributeSet?) : View(context,
                 dataset.points.forEachIndexed { index, point ->
                     // move path to first data point,
                     if (index == 0) {
-                        moveTo(chartBounds.start, baseline.yPointToPixels())
+                        moveTo(chartBounds.start + point.x.xPointToPixels(),
+                            point.y.yPointToPixels())
                         return@forEachIndexed
                     }
 
@@ -620,7 +621,7 @@ open class LiveChartView(context: Context, attrs: AttributeSet?) : View(context,
                 }
                 lineTo(chartBounds.start + dataset.points.last().x.xPointToPixels(),
                     chartBounds.bottom)
-                lineTo(chartBounds.start,
+                lineTo(chartBounds.start + dataset.points.first().x.xPointToPixels(),
                     chartBounds.bottom)
             }
 
@@ -643,6 +644,8 @@ open class LiveChartView(context: Context, attrs: AttributeSet?) : View(context,
                     fillColor,
                     Color.parseColor(LiveChartAttributes.TRANSPARENT_COLOR),
                     Shader.TileMode.CLAMP)
+            } else {
+                datasetFillPaint.color = fillColor
             }
 
             setChartHighlightColor()


### PR DESCRIPTION
Fixes the dataset fill starting always in x=0 coordinate. Fill path now starts with first data point.

Closes #26