### PR TITLE
Feature - Set Overlay Position Manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,30 @@ Public Methods for LiveChart:
     fun disableTouchOverlay(): LiveChart
 
     /**
+     * Manually set the INITIAL nearest DataPoint position of the touch overlay.
+     */
+    @PublicApi
+    fun setInitialTouchOverlayPosition(point: DataPoint): LiveChart
+
+    /**
+     * Manually set the overlay nearest DataPoint position at any time after the drawing operation.
+     * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
+     * need to be extracted.
+     */
+    @PublicApi
+    fun setTouchOverlayPosition(point: DataPoint)
+
+    /**
+     * Manually set the overlay REAL pixel position at any time after the drawing operation.
+     * This is useful for animating the touch overlay.
+     * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
+     * need to be extracted.
+     * The given position will be mapped onto the path created if it exists.
+     */
+    @PublicApi
+    fun setTouchOverlayRealPosition(position: Float)
+
+    /**
      * Draw on chart and bind overlay to dataset.
      */
     fun drawDataset()

--- a/README.md
+++ b/README.md
@@ -200,7 +200,27 @@ You can also style a number of attributes through the XML layout attributes. For
         app:overlayCircleDiameter="8dp"/>
 ```
 
-For a full set of available attributes you can check the `LiveChartView` reference.
+The current set of available attributes are:
+
+```xml
+    <attr name="labelTextColor" format="reference|color" />
+    <attr name="pathColor" format="reference|color"/>
+    <attr name="secondPathColor" format="reference|color"/>
+    <attr name="fillColor" format="reference|color"/>
+    <attr name="baselineColor" format="reference|color"/>
+    <attr name="boundsColor" format="reference|color"/>
+    <attr name="positiveColor" format="reference|color"/>
+    <attr name="negativeColor" format="reference|color"/>
+    <attr name="mainCornerRadius" format="dimension"/>
+    <attr name="secondCornerRadius" format="dimension"/>
+    <attr name="pathStrokeWidth" format="dimension"/>
+    <attr name="baselineStrokeWidth" format="dimension"/>
+    <attr name="baselineDashGap" format="dimension"/>
+    <attr name="labelTextHeight" format="dimension"/>
+    <attr name="overlayLineColor" format="reference|color"/>
+    <attr name="overlayCircleColor" format="reference|color"/>
+    <attr name="overlayCircleDiameter" format="dimension"/>
+```
 
 ## Second Dataset
 

--- a/app/src/main/java/com/yabu/livechartdemoapp/MainActivity.kt
+++ b/app/src/main/java/com/yabu/livechartdemoapp/MainActivity.kt
@@ -3,6 +3,7 @@ package com.yabu.livechartdemoapp
 import android.annotation.SuppressLint
 import android.graphics.Color
 import android.os.Bundle
+import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import com.yabu.livechart.model.DataPoint
 import com.yabu.livechart.model.Dataset
@@ -42,6 +43,7 @@ class MainActivity : AppCompatActivity() {
             .setLiveChartStyle(chartStyle)
             .drawTouchOverlayAlways()
             .drawSmoothPath()
+            .setInitialTouchOverlayPosition(dataset.points[3].x)
             .setOnTouchCallbackListener(object : LiveChart.OnTouchCallback {
                 @SuppressLint("SetTextI18n")
                 override fun onTouchCallback(point: DataPoint) {

--- a/livechart/src/main/java/com/yabu/livechart/view/LiveChart.kt
+++ b/livechart/src/main/java/com/yabu/livechart/view/LiveChart.kt
@@ -250,32 +250,34 @@ class LiveChart(context: Context, attrs: AttributeSet? = null) : FrameLayout(con
     }
 
     /**
-     * Manually set the INITIAL nearest position of the touch overlay.
-     * ONLY use for initial setting as there is a calculation cost
-     * to map the path coordinates before the drawDataset() call is performed.
-     *
-     * The given position will be mapped onto the path created if it exists.
-     * Note a Float value is rounded to an Int to avoid half pixel positions.
-     * IMPORTANT this must be called AFTER setDataset() as the pathCoordinates
-     * need to be extracted. Also after .drawSmoothPath() if you are using it
-     * to take into consideration the smooth path coordinates.
+     * Manually set the INITIAL nearest DataPoint position of the touch overlay.
      */
     @PublicApi
-    fun setInitialTouchOverlayPosition(position: Float): LiveChart {
-        overlay.setInitialPosition(position)
+    fun setInitialTouchOverlayPosition(point: DataPoint): LiveChart {
+        overlay.setInitialPosition(point.x)
 
         return this
     }
 
     /**
-     * Set manually the overlay position at any time after the drawing operation.
+     * Set manually the overlay nearest DataPoint position at any time after the drawing operation.
+     * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
+     * need to be extracted.
+     */
+    @PublicApi
+    fun setTouchOverlayPosition(point: DataPoint) {
+        overlay.setDataPointPosition(point.x)
+    }
+
+    /**
+     * Set manually the overlay real pixel position at any time after the drawing operation.
+     * This is useful for animating the touch overlay.
      * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
      * need to be extracted.
      * The given position will be mapped onto the path created if it exists.
-     * Note a Float value is rounded to an Int to avoid half pixel positions.
      */
     @PublicApi
-    fun setTouchOverlayPosition(position: Float) {
+    fun setTouchOverlayRealPosition(position: Float) {
         overlay.setPosition(position)
     }
 

--- a/livechart/src/main/java/com/yabu/livechart/view/LiveChart.kt
+++ b/livechart/src/main/java/com/yabu/livechart/view/LiveChart.kt
@@ -250,6 +250,36 @@ class LiveChart(context: Context, attrs: AttributeSet? = null) : FrameLayout(con
     }
 
     /**
+     * Manually set the INITIAL nearest position of the touch overlay.
+     * ONLY use for initial setting as there is a calculation cost
+     * to map the path coordinates before the drawDataset() call is performed.
+     *
+     * The given position will be mapped onto the path created if it exists.
+     * Note a Float value is rounded to an Int to avoid half pixel positions.
+     * IMPORTANT this must be called AFTER setDataset() as the pathCoordinates
+     * need to be extracted. Also after .drawSmoothPath() if you are using it
+     * to take into consideration the smooth path coordinates.
+     */
+    @PublicApi
+    fun setInitialTouchOverlayPosition(position: Float): LiveChart {
+        overlay.setInitialPosition(position)
+
+        return this
+    }
+
+    /**
+     * Set manually the overlay position at any time after the drawing operation.
+     * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
+     * need to be extracted.
+     * The given position will be mapped onto the path created if it exists.
+     * Note a Float value is rounded to an Int to avoid half pixel positions.
+     */
+    @PublicApi
+    fun setTouchOverlayPosition(position: Float) {
+        overlay.setPosition(position)
+    }
+
+    /**
      * Draw on chart and bind overlay to dataset.
      */
     @PublicApi

--- a/livechart/src/main/java/com/yabu/livechart/view/LiveChartTouchOverlay.kt
+++ b/livechart/src/main/java/com/yabu/livechart/view/LiveChartTouchOverlay.kt
@@ -165,7 +165,6 @@ class LiveChartTouchOverlay(context: Context, attrs: AttributeSet?)
     /**
      * Manually set the INITIAL nearest position of the touch overlay.
      * The given position will be mapped onto the path created if it exists.
-     * Note a Float value is rounded to an Int to avoid half pixel positions.
      * IMPORTANT this must be called AFTER setDataset() as the pathCoordinates
      * need to be extracted. Also after .drawSmoothPath() if you are using it
      * to take into consideration the smooth path coordinates.
@@ -176,9 +175,29 @@ class LiveChartTouchOverlay(context: Context, attrs: AttributeSet?)
     }
 
     /**
-     * Manually set the nearest position of the touch overlay.
+     * Manually set the nearest data point position of the touch overlay.
      * The given position will be mapped onto the path created if it exists.
-     * Note a Float value is rounded to an Int to avoid half pixel positions.
+     * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
+     * need to be extracted.
+     */
+    @PublicApi
+    fun setDataPointPosition(position: Float) {
+        val xPos = position.xPointToPixels()
+
+        val coordinates = pathCoordinates.firstOrNull {
+            it[0].roundToInt() == xPos.roundToInt()
+        }
+
+        if (coordinates != null) {
+            overlay.x = coordinates[0] - (chartStyle.overlayCircleDiameter/2)
+            overlayPoint.y = coordinates[1] - (chartStyle.overlayCircleDiameter/2)
+        }
+    }
+
+    /**
+     * Manually set the nearest position of the touch overlay in pixel terms.
+     * Useful to make animations with the overlay.
+     * The given position will be mapped onto the path created if it exists.
      * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
      * need to be extracted.
      */
@@ -289,7 +308,6 @@ class LiveChartTouchOverlay(context: Context, attrs: AttributeSet?)
                 if (initialXPosition > -1f) {
                     val xPos = initialXPosition.xPointToPixels()
                     val coordinates = pathCoordinates.firstOrNull {
-                        Log.d("TouchOverlay", "${xPos}")
                         it[0].roundToInt() == xPos.roundToInt()
                     }
 

--- a/livechart/src/main/java/com/yabu/livechart/view/LiveChartTouchOverlay.kt
+++ b/livechart/src/main/java/com/yabu/livechart/view/LiveChartTouchOverlay.kt
@@ -6,13 +6,11 @@ import android.content.res.ColorStateList
 import android.graphics.Path
 import android.graphics.PathMeasure
 import android.util.AttributeSet
-import android.util.DisplayMetrics
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import com.yabu.livechart.R
 import com.yabu.livechart.model.Bounds
 import com.yabu.livechart.model.DataPoint
@@ -21,7 +19,6 @@ import com.yabu.livechart.utils.EPointF
 import com.yabu.livechart.utils.PolyBezierPathUtil
 import com.yabu.livechart.utils.PublicApi
 import com.yabu.livechart.view.LiveChart.OnTouchCallback
-import java.lang.Exception
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.round
@@ -73,6 +70,11 @@ class LiveChartTouchOverlay(context: Context, attrs: AttributeSet?)
      * Second dataset
      */
     private var secondDataset: Dataset = Dataset.new()
+
+    /**
+     * Initial Overlay X Position. Defaults to -1 (Not set)
+     */
+    private var initialXPosition: Float = -1f
 
     /**
      * Path generated from dataset points.
@@ -158,6 +160,41 @@ class LiveChartTouchOverlay(context: Context, attrs: AttributeSet?)
     fun alwaysDisplay() {
         overlay.alpha = 1f
         alwaysDisplay = true
+    }
+
+    /**
+     * Manually set the INITIAL nearest position of the touch overlay.
+     * The given position will be mapped onto the path created if it exists.
+     * Note a Float value is rounded to an Int to avoid half pixel positions.
+     * IMPORTANT this must be called AFTER setDataset() as the pathCoordinates
+     * need to be extracted. Also after .drawSmoothPath() if you are using it
+     * to take into consideration the smooth path coordinates.
+     */
+    @PublicApi
+    fun setInitialPosition(position: Float) {
+        initialXPosition = position
+    }
+
+    /**
+     * Manually set the nearest position of the touch overlay.
+     * The given position will be mapped onto the path created if it exists.
+     * Note a Float value is rounded to an Int to avoid half pixel positions.
+     * IMPORTANT this must be called AFTER drawDataset() as the pathCoordinates
+     * need to be extracted.
+     */
+    @PublicApi
+    fun setPosition(position: Float) {
+        // Extract coordinate from stored array
+        val roundedPos = position.roundToInt()
+
+        val coordinates = pathCoordinates.firstOrNull {
+            (it[0]).roundToInt() == roundedPos
+        }
+
+        if (coordinates != null) {
+            overlay.x = coordinates[0] - (chartStyle.overlayCircleDiameter/2)
+            overlayPoint.y = coordinates[1] - (chartStyle.overlayCircleDiameter/2)
+        }
     }
 
     /**
@@ -249,10 +286,23 @@ class LiveChartTouchOverlay(context: Context, attrs: AttributeSet?)
             extractCoordinatesFromPath()
 
             try {
-                // Set to default in the middle of the path
-                val coordinates = pathCoordinates[round(pathCoordinates.size.div(2).toFloat()).toInt()]
-                overlay.x = coordinates[0] - (chartStyle.overlayCircleDiameter/2)
-                overlayPoint.y = coordinates[1] - (chartStyle.overlayCircleDiameter/2)
+                if (initialXPosition > -1f) {
+                    val xPos = initialXPosition.xPointToPixels()
+                    val coordinates = pathCoordinates.firstOrNull {
+                        Log.d("TouchOverlay", "${xPos}")
+                        it[0].roundToInt() == xPos.roundToInt()
+                    }
+
+                    if (coordinates != null) {
+                        overlay.x = coordinates[0] - (chartStyle.overlayCircleDiameter/2)
+                        overlayPoint.y = coordinates[1] - (chartStyle.overlayCircleDiameter/2)
+                    }
+                } else {
+                    // Set to default in the middle of the path
+                    val coordinates = pathCoordinates[round(pathCoordinates.size.div(2).toFloat()).toInt()]
+                    overlay.x = coordinates[0] - (chartStyle.overlayCircleDiameter/2)
+                    overlayPoint.y = coordinates[1] - (chartStyle.overlayCircleDiameter/2)
+                }
             } catch (e: Exception) {
                 Log.e("Overlay", e.message.toString())
             }


### PR DESCRIPTION
## Changelog
- Set Overlay position manually initially and after draw operation (27cd1d9cf7d450ef699bd0515e2cc537dab715fc)
- Real Pixel Position v DataPoint position setter methods (d3f41d0c671515f3b68ec03c1002eb8c8a0ba3ff)
- Add all the available attributes for LiveChartView in docs (4196465dbc5604c39d605802f0b4cab472112283)